### PR TITLE
Fixed AttributeError

### DIFF
--- a/pages/search_indexes.py
+++ b/pages/search_indexes.py
@@ -29,7 +29,7 @@ class RealTimePageIndex(RealTimeSearchIndex):
         """Used when the entire index for model is updated."""
         return Page.objects.published()
 
-if settings.PAGE_REAL_TIME_SEARCH:
+if getattr(settings, 'PAGE_REAL_TIME_SEARCH', None):
     site.register(Page, RealTimePageIndex)
 else:
     site.register(Page, PageIndex)


### PR DESCRIPTION
I tried to update pages-cms version to 1.4.2, but I got an error:
AttributeError: 'Settings' object has no attribute 'PAGE_REAL_TIME_SEARCH'
