### PR TITLE
Import settings bug fix

### DIFF
--- a/pages/search_indexes.py
+++ b/pages/search_indexes.py
@@ -1,6 +1,6 @@
 """Django haystack `SearchIndex` module."""
 from pages.models import Page
-from django.conf import settings
+from pages import settings
 
 from haystack.indexes import SearchIndex, CharField, DateTimeField, RealTimeSearchIndex
 from haystack import site


### PR DESCRIPTION
In search_indexes.py file PageCMS import application settings instead of its own settings and that may cause AttributeError when django tries initialize search indexes.
