### PR TITLE
this change gives the possibility to specify the variable that holds the extra context

### DIFF
--- a/pages/http.py
+++ b/pages/http.py
@@ -113,6 +113,11 @@ def pages_view(view):
                 only_context=True, delegation=False)
             context = response
             kwargs.update(context)
+            extra_context_var = kwargs.pop('extra_context_var',None)
+            if extra_context_var:
+                kwargs.update({extra_context_var:response})
+            else:
+                kwargs.update(context)
         return view(request, *args, **kwargs)
     return pages_view_decorator
 


### PR DESCRIPTION
my change enables the use of decorator pages_view with django.contrib.auth.views.login for example.
Please note also the other pull request that deletes a line I forgot to remove.
