### PR TITLE
Fix for fatal packaging issue on non-unix platforms

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,11 +13,11 @@ recursive-include requirements *
 recursive-include pages/templates *
 recursive-include pages/static *
 recursive-include pages/locale *
-recursive-include pages/ *.css
-recursive-include pages/ *.js
-recursive-include pages/ *.html
-recursive-include pages/ *.mo
-recursive-include pages/ *.po
+recursive-include pages *.css
+recursive-include pages *.js
+recursive-include pages *.html
+recursive-include pages *.mo
+recursive-include pages *.po
 global-exclude *.pyc
 global-exclude coverage/*
 # this important to prune at the end


### PR DESCRIPTION
Removed trailing slashes from dir names in MANIFEST.in which was breaking installs on non-unix platforms (https://github.com/batiste/django-page-cms/issues/36)
