### PR TITLE
Two bugs in resolving page method

### DIFF
--- a/pages/views.py
+++ b/pages/views.py
@@ -98,20 +98,23 @@ class Details(object):
             exclude_drafts=(not is_staff))
         if page:
             return page
-        # if the complete path didn't worked out properly we gonna
+        # if the complete path didn't worked out properly 
+        # and if didn't used PAGE_USE_STRICT_URL setting we gonna
         # try to see if it might be a delegation page.
         # To do that we remove the right part of the url and try again
         # to find a page that match
-        path = remove_slug(path)
-        while path is not None:
-            page = Page.objects.from_path(path, lang,
-                exclude_drafts=(not is_staff))
-            # find a match. Is the page delegating?
-            if page:
-                if page.delegate_to:
-                    return page
+        if not settings.PAGE_USE_STRICT_URL:
             path = remove_slug(path)
-        return page
+            while path is not None:
+                page = Page.objects.from_path(path, lang,
+                    exclude_drafts=(not is_staff))
+                # find a match. Is the page delegating?
+                if page:
+                    if page.delegate_to:
+                        return page
+                path = remove_slug(path)
+                
+        return None
 
     def resolve_alias(self, request, path, lang):
         alias = PageAlias.objects.from_path(request, path, lang)


### PR DESCRIPTION
I have found two bugs in resolving page method:
1. If I set PAGE_USE_STRICT_URL to True and open non-existing page I get not the 404 page but page from upper level of path.
2. And if there is no delegation page the cms returns root page.
