### PR TITLE
Update doc for what code does to extra_context

### DIFF
--- a/doc/display-content.rst
+++ b/doc/display-content.rst
@@ -136,7 +136,7 @@ help if you want to override some default behavior::
 
         def extra_context(self, request, context):
             lastest_news = News.object.all()
-            return {'news': lastest_news}
+            context.update({'news': lastest_news})
 
     details = NewsView()
 


### PR DESCRIPTION
It said to return context, but the return value is ignored
and the superclass method ends in .update()
