### PR TITLE
More leeway in requirements

### DIFF
--- a/requirements/external_apps.txt
+++ b/requirements/external_apps.txt
@@ -1,4 +1,4 @@
-django>=1.5.0,<=1.6.0
+django>=1.5.0,<1.7
 django-mptt==0.6.0
 html5lib==0.95
-south==0.8.2
+south>0.8,<0.9


### PR DESCRIPTION
Hi!

Something pulled in south==0.8.4 and thus we couldn't upgrade django-page-cms easily, because of a version conflict.

I'm not entirely sure about eg. django-mptt but I'd believe Django and South are packages that can be trusted
with a bit of variation in the versions.

What do you think? It fixed our problem at least :)
