### PR TITLE
Image placeholder unicode issue

### DIFF
--- a/pages/placeholders.py
+++ b/pages/placeholders.py
@@ -250,7 +250,7 @@ def get_filename(page, placeholder, data):
     filename = os.path.join(
         settings.PAGE_UPLOAD_ROOT,
         'page_' + str(page.id),
-        placeholder.name + '-' + str(time.time()) + '-' + str(data)
+        placeholder.name + '-' + str(time.time()) + '-' + str(data).decode('utf-8')
     )
     return filename
 


### PR DESCRIPTION
Here's bugfix for the issue I caught trying to upload image file contained cyrillic symbols.

```
  File "/srv/www/test/ENV/local/lib/python2.7/site-packages/pages/placeholders.py", line 285, in save
    filename = get_filename(page, self, data)

  File "/srv/www/test/ENV/local/lib/python2.7/site-packages/pages/placeholders.py", line 250, in get_filename
    placeholder.name + '-' + str(time.time()) + '-' + str(data)

UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 0: ordinal not in range(128)
```
