### PR TITLE
Updated requirement for South minimum version to be PEP 440 compliant.

### DIFF
--- a/requirements/external_apps.txt
+++ b/requirements/external_apps.txt
@@ -1,5 +1,5 @@
 django>=1.5.0,<1.7
 django-mptt==0.6.0
-south>0.8,<0.9
+south>=0.8,<0.9
 six>=1.5.2
 Pillow


### PR DESCRIPTION
Since version 8.0, setuptools is PEP 440 compliant. The current requirements definition for South use a syntax that was okay for pre-8.0 setuptools, but anyone using 8.0 or above will get a requirements conflict that South >0.8,<0.9 is required but 0.8.4 is installed on any subsequent runs. This small change fixes that.