### PR TITLE
Get travis running against latest python and django versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,19 @@ language: python
 python:
   - "2.7"
   - "3.3"
+env:
+  - DJANGO_VERSION=1.6.11
+matrix:
+  include:
+    - python: "3.3"
+      env: DJANGO_VERSION=1.7.7
+    - python: "3.4"
+      env: DJANGO_VERSION=1.7.7
 # command to install dependencies
 install:
-  - "pip install -r requirements/external_apps.txt"
-  - "pip install -r requirements/test_apps.txt"
+  - pip install -r requirements/external_apps.txt
+  - pip install -r requirements/test_apps.txt
+  - pip install -q django==$DJANGO_VERSION
 # command to run tests
-script: "python pages/test_runner.py"
+script: 
+  - python pages/test_runner.py


### PR DESCRIPTION
The pull request has been merged for django 1.7:

- https://github.com/batiste/django-page-cms/commit/721efd74545767fecc596f23c12569073e6e192f

Now, need to get the test suite running against latest django and latest python.