### PR TITLE
Clean upload file names

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,6 +13,7 @@ Released the <to be determined>.
       and causing possible weirdness
     * Grappelli support
     * Support for section (grouping) fields in admin
+    * Clean upload file names
     * Bug fixes
     * Code cleanup
 

--- a/pages/placeholders.py
+++ b/pages/placeholders.py
@@ -3,6 +3,7 @@ from pages.widgets_registry import get_widget
 from pages import settings
 from pages.models import Content
 from pages.widgets import ImageInput, FileInput
+from pages.utils import slugify
 
 from django import forms
 from django.core.mail import send_mail
@@ -250,10 +251,12 @@ def get_filename(page, placeholder, data):
     """
     Generate a stable filename using the orinal filename.
     """
+    name_parts = data.name.split('.')
+    name = slugify('.'.join(name_parts[:-1]), allow_unicode=True)
     filename = os.path.join(
         settings.PAGE_UPLOAD_ROOT,
         'page_' + str(page.id),
-        placeholder.ctype + '-' + str(time.time()) + '-' + data.name
+        placeholder.ctype + '-' + str(time.time()) + '-' + name + '.' + name_parts[-1]
     )
     return filename
 

--- a/pages/tests/test_regression.py
+++ b/pages/tests/test_regression.py
@@ -290,9 +290,9 @@ class RegressionTestCase(TestCase):
         """Problem with encoding file names"""
         placeholder = PlaceholderNode("placeholdername")
         page = self.new_page({'slug': 'page1'})
-        fakefile = SimpleUploadedFile(name=six.u("АБВГДЕЖ.pdf"), content=six.b('bytes'))
+        fakefile = SimpleUploadedFile(name=u"АБВГДЕЖ.pdf", content=six.b('bytes'))
         filename = get_filename(page, placeholder, fakefile)
-        self.assertTrue(fakefile.name in filename)
+        self.assertTrue(fakefile.name.lower() in filename)
         self.assertTrue("page_%d" % page.id in filename)
         self.assertTrue(placeholder.name in filename)
 

--- a/pages/tests/test_templates.py
+++ b/pages/tests/test_templates.py
@@ -348,10 +348,11 @@ class TemplateTestCase(TestCase):
     def test_get_filename(self):
         placeholder = PlaceholderNode("placeholdername")
         page = self.new_page({'slug': 'page1'})
-        fakefile = SimpleUploadedFile(name=six.u("myfile.pdf"), content=six.b('bytes'))
-        self.assertTrue(fakefile.name in get_filename(page, placeholder, fakefile))
-        self.assertTrue("page_%d" % page.id in get_filename(page, placeholder, fakefile))
-        self.assertTrue(placeholder.name in get_filename(page, placeholder, fakefile))
+        fakefile = SimpleUploadedFile(name=u"some {}[]@$%*()+myfile.pdf", content=six.b('bytes'))
+        filename = get_filename(page, placeholder, fakefile)
+        self.assertTrue('some-myfile.pdf' in filename)
+        self.assertTrue("page_%d" % page.id in filename)
+        self.assertTrue(placeholder.name in filename)
 
     def test_json_placeholder(self):
         tpl = ("{% load pages_tags %}{% jsonplaceholder p1 as v %}{{ v.a }}")


### PR DESCRIPTION
I also removed `six.u()` because it is working wrong on Python2 (there is a note: https://pythonhosted.org/six/index.html#six.u) eg. "АБВГДЕЖ.pdf" was converted to "ÐÐÐÐÐÐÐ.pdf".
Python 3.3 bring back support for `u""` and Python 3.0-3.2 is no more supported.