### PR TITLE
Using requirements-builder for the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,37 @@
+sudo: false
+
 language: python
+
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "nightly"
+
 env:
-  - DJANGO="Django<1.9"
-  - DJANGO="Django<1.10"
-matrix:
-  exclude:
-    # Django 1.9+ no longer supports python 3.2/3.3
-    - python: "3.2"
-      env: DJANGO="Django<1.10"
-    - python: "3.3"
-      env: DJANGO="Django<1.10"
-# command to install dependencies
+  - >
+    REQUIREMENTS=min
+    DJANGO="Django==1.8.0"
+  - >
+    REQUIREMENTS=pypi
+    DJANGO="Django<1.10"
+  - >
+    REQUIREMENTS=dev
+    DJANGO="Django<1.10"
+
+before_install:
+  - "pip install coveralls git+https://github.com/greut/requirements-builder@output#egg=requirements-builder"
+  - "requirements-builder --level=min setup.py > requirements-min.txt"
+  - "requirements-builder --level=pypi setup.py > requirements-pypi.txt"
+  - "requirements-builder --level=dev --req=requirements-devel.txt setup.py > requirements-dev.txt"
+
 install:
+  - "pip install -r requirements-${REQUIREMENTS}.txt"
+  - "pip install ${DJANGO}"
   - "pip install -e .[tests]"
-  - "pip install coveralls"
-  - "pip install $DJANGO"
-# command to run tests
-script: "coverage run --source=pages pages/test_runner.py"
+
+script:
+  - "coverage run --source=pages pages/test_runner.py"
+
 after_success:
-  coveralls
-sudo: false
+  - "coveralls"

--- a/pages/tests/test_selenium.py
+++ b/pages/tests/test_selenium.py
@@ -20,6 +20,7 @@ class SeleniumTestCase(TestCase, LiveServerTestCase):
 
     def setUp(self):
         self.browser = webdriver.PhantomJS()
+        self.browser.set_page_load_timeout(10)
         client = self.get_admin_client()
 
         # setUp is where you instantiate the selenium webdriver and loads the browser.

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,0 +1,11 @@
+-e git+https://github.com/django-mptt/django-mptt#egg=django-mptt
+-e git+https://github.com/python-pillow/Pillow#egg=Pillow
+-e git+https://github.com/tqdm/tqdm#egg=tqdm
+-e git+https://github.com/alex/django-taggit#egg=django-taggit
+-e git+https://github.com/kennethreitz/requests#egg=requests
+-e git+https://github.com/django-haystack/django-haystack#egg=django-haystack
+-e git+https://github.com/waylan/Python-Markdown#egg=Markdown
+-e hg+http://bitbucket.org/mchaput/whoosh#egg=Whoosh
+-e git+https://github.com/django-ckeditor/django-ckeditor#egg=django-ckeditor
+-e hg+https://bitbucket.org/izi/polib/#egg=polib
+-e git+https://github.com/tomchristie/django-rest-framework#egg=djangorestframework

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -1,8 +1,0 @@
-# All the dependencies required for running the CMS
--r base.txt
--e git+https://github.com/django-haystack/django-haystack@42f53cda9a770ff7daf2ff792cbcab5cd843e2a7#egg=django-haystack
-Markdown>=2.6.6,<2.7.0
-Whoosh>=2.7.4,<2.8.0
-django-ckeditor>=5.0.3,<5.1.0
-polib>=1.0.7,<1.1.0
-djangorestframework>=3.3.2,<3.4.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,9 +1,0 @@
-# Basic dependencies required for running the CMS
-# Keep that commented or tox will explode
-# Django>=1.8,<1.10
-django-mptt>=0.8.3,<0.9.0
-six>=1.10.0,<1.11.0
-Pillow>=3.2.0,<3.3.0
-tqdm>=4.4.0,<4.5.0
-django-taggit>=0.18.1,<0.19.0
-requests>=2.9.0,<3.0.0

--- a/requirements/documentation.txt
+++ b/requirements/documentation.txt
@@ -1,3 +1,0 @@
--r all.txt
-Sphinx>=1.4.3,<1.5.0
-sphinx-better-theme==0.13

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -1,4 +1,0 @@
-# Requirement used in the documentation and install
-Django>=1.8,<1.10
--r all.txt
-django-page-cms

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,3 +1,0 @@
--r all.txt
-selenium
-coverage

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
-from pkg_resources import require, DistributionNotFound
-import pages
 import os
+import pages
+
 package_name = 'django-page-cms'
 
+base = os.path.dirname(__file__)
 
 def local_open(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname))
+    return open(os.path.join(base, fname), 'r')
 
 
 data_dirs = []
@@ -34,21 +35,21 @@ url_schema = 'http://pypi.python.org/packages/source/d/%s/%s-%s.tar.gz'
 download_url = url_schema % (package_name, package_name, pages.__version__)
 
 install_requires = [
-    'django-mptt>=0.8.3,<0.9.0',
-    'six>=1.10.0,<1.11.0',
-    'Pillow>=3.2.0,<3.3.0',
-    'tqdm>=4.4.0,<4.5.0',
-    'django-taggit>=0.18.1,<0.19.0',
-    'requests>=2.9.0,<3.0.0',
+    'django-mptt>=0.8.3',
+    'six>=1.10.0',
+    'Pillow>=3.2.0',
+    'tqdm>=4.4.0',
+    'django-taggit>=0.18.1',
+    'requests>=2.9.0',
 ]
 
 extra = [
     'django-haystack',
-    'Markdown>=2.6.6,<2.7.0',
-    'Whoosh>=2.7.4,<2.8.0',
-    'django-ckeditor>=5.0.3,<5.1.0',
-    'polib>=1.0.7,<1.1.0',
-    'djangorestframework>=3.3.2,<3.4.0'
+    'Markdown>=2.6.6',
+    'Whoosh>=2.7.4',
+    'django-ckeditor>=5.0.3',
+    'polib>=1.0.7',
+    'djangorestframework>=3.3.2'
 ]
 
 tests_require = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,25 @@
 [tox]
 skipsdist = True
+
 envlist =
-    {py27}-django-{18,19}
-    {py33}-django-{18}
-    {py34}-django-{18,19}
-    {py35}-django-{18,19}
+    {py27}-django-{min,pypi,dev}
+    {py34}-django-{min,pypi,dev}
+    {py35}-django-{min,pypi,dev}
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}
-deps =
-    django-18: Django>=1.8,<1.9
-    django-19: Django>=1.9,<1.10
+
 commands =
+    pip install coveralls git+https://github.com/greut/requirements-builder@output#egg=requirements-builder
+    min: requirements-builder -l min -o .tox/requirements-min.txt setup.py
+    min: pip install -r .tox/requirements-min.txt
+    min: pip install Django==1.8.0
+    pypi: requirements-builder -l pypi -o .tox/requirements-pypi.txt setup.py
+    pypi: pip install -r .tox/requirements-pypi.txt
+    pypi: pip install Django<1.10
+    dev: requirements-builder -l dev -r requirements-devel.txt -o .tox/requirements-dev.txt setup.py
+    dev: pip install -r .tox/requirements-dev.txt
+    dev: pip install Django<1.10
     pip install -e .[tests]
-    django: python pages/test_runner.py
+    python pages/test_runner.py


### PR DESCRIPTION
* Drop Python 3.2 and 3.3
* Add Python nightly
* Add dev requirements to test agains the github version of the deps

Sadly, it requires a little from inveniosoftware/requirements-builder#7 before everything could be alrighty.

The testing matrix is now a little bit crazy, but probably worth it ;-)

**EDIT:** as it points out, you were way too conservative with your version requirements.