### PR TITLE
Fix failing template.render() in LoadEditNode on Django 1.11

### DIFF
--- a/pages/templatetags/pages_tags.py
+++ b/pages/templatetags/pages_tags.py
@@ -456,7 +456,7 @@ class LoadEditNode(template.Node):
         with context.push():
             context['form'] = form
             context['edit_enabled'] = request.COOKIES.get('enable_edit_mode')
-            content = template.render(context)
+            content = template.render(context.flatten())
 
         return content
 


### PR DESCRIPTION
So, I tried using page-cms under Django 1.11. Unfortunately after I created a page in the admin panel and opened it, I received an exception from Django. In Django versions below 1.11, everything used to work fine.

How to reproduce:
1. Install Django 1.11
2. Create a new page in admin and publish it.
3. Open the page in front-end.

Here's the traceback
```
ERROR:django.request:Internal Server Error: /new
Traceback (most recent call last):
  File "/home/michal/dev/ar/django-page-cms/venv/lib/python3.6/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/home/michal/dev/ar/django-page-cms/venv/lib/python3.6/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/home/michal/dev/ar/django-page-cms/venv/lib/python3.6/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/home/michal/dev/ar/django-page-cms/venv/lib/python3.6/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "./../pages/views.py", line 97, in __call__
    return render(request, template_name, context)
  File "/home/michal/dev/ar/django-page-cms/venv/lib/python3.6/site-packages/django/shortcuts.py", line 30, in render
    content = loader.render_to_string(template_name, context, request, using=using)
  File "/home/michal/dev/ar/django-page-cms/venv/lib/python3.6/site-packages/django/template/loader.py", line 68, in render_to_string
    return template.render(context, request)
  File "/home/michal/dev/ar/django-page-cms/venv/lib/python3.6/site-packages/django/template/backends/django.py", line 66, in render
    return self.template.render(context)
  File "/home/michal/dev/ar/django-page-cms/venv/lib/python3.6/site-packages/django/template/base.py", line 207, in render
    return self._render(context)
  File "/home/michal/dev/ar/django-page-cms/venv/lib/python3.6/site-packages/django/template/base.py", line 199, in _render
    return self.nodelist.render(context)
  File "/home/michal/dev/ar/django-page-cms/venv/lib/python3.6/site-packages/django/template/base.py", line 990, in render
    bit = node.render_annotated(context)
  File "/home/michal/dev/ar/django-page-cms/venv/lib/python3.6/site-packages/django/template/base.py", line 957, in render_annotated
    return self.render(context)
  File "./../pages/templatetags/pages_tags.py", line 459, in render
    content = template.render(context)
  File "/home/michal/dev/ar/django-page-cms/venv/lib/python3.6/site-packages/django/template/backends/django.py", line 64, in render
    context = make_context(context, request, autoescape=self.backend.engine.autoescape)
  File "/home/michal/dev/ar/django-page-cms/venv/lib/python3.6/site-packages/django/template/context.py", line 287, in make_context
    raise TypeError('context must be a dict rather than %s.' % context.__class__.__name__)
TypeError: context must be a dict rather than RequestContext.```