### PR TITLE
Increase language code length

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,3 +24,4 @@ Cans https://github.com/cans
 Francesco Facconi
 Markus "mjtorn" Törnqvist
 Remigiusz Dymecki
+elky

--- a/pages/migrations/0007_language_code.py
+++ b/pages/migrations/0007_language_code.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pages', '0006_auto_20170119_0628'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='content',
+            name='language',
+            field=models.CharField(max_length=7, verbose_name='language'),
+        ),
+    ]

--- a/pages/models.py
+++ b/pages/models.py
@@ -510,8 +510,8 @@ class Content(models.Model):
     """A block of content, tied to a :class:`Page <pages.models.Page>`,
     for a particular language"""
 
-    # languages could have five characters : Brazilian Portuguese is pt-br
-    language = models.CharField(_('language'), max_length=5, blank=False)
+    # languages could have seven characters : Simplified Chinese is zh-hans
+    language = models.CharField(_('language'), max_length=7, blank=False)
     body = models.TextField(_('body'), blank=True)
     type = models.CharField(
         _('type'), max_length=100, blank=False,


### PR DESCRIPTION
Ref #178 

According to [django language info file](https://github.com/django/django/blob/master/django/conf/locale/__init__.py#L536) there are some languages that have code length more than 5, e.g. `zh-hans`.

Any ideas how to test this case?

Thanks