### PR TITLE
Fix DjangoUnicodeDecodeError for FileInput

### DIFF
--- a/pages/widgets.py
+++ b/pages/widgets.py
@@ -58,7 +58,7 @@ class RichTextarea(Textarea):
 register_widget(RichTextarea)
 
 
-insert_image_link = '''
+insert_image_link = u'''
 <br>
 <button title='insert image from the media library' class='image-lookup-{name}'>
     From media library


### PR DESCRIPTION
Getting `DjangoUnicodeDecodeError` when edit page with i18n enabled in admin.

```
'ascii' codec can't decode byte 0xd0 in position 360: ordinal not in range(128). You passed in <django.forms.boundfield.BoundField object at 0x111251990> (<class 'django.forms.boundfield.BoundField'>)
```
