### PR TITLE
Switching from empty call to `static` to `get_static_prefix`

### DIFF
--- a/pages/templates/admin/pages/page/change_form.html
+++ b/pages/templates/admin/pages/page/change_form.html
@@ -5,7 +5,7 @@
 
 {% block extrahead %}{{ block.super }}
 <script type="text/javascript" src="{% static "admin/js/urlify.js" %}"></script>
-<script type="text/javascript">var static_url = "{% static "" %}";</script>
+<script type="text/javascript">var static_url = "{% get_static_prefix %}";</script>
 {% endblock %}
 
 {% block content %}

--- a/pages/templates/admin/pages/page/change_list.html
+++ b/pages/templates/admin/pages/page/change_list.html
@@ -5,7 +5,7 @@
 {% block coltype %}flex{% endblock %}
 
 {% block extrahead %}{{ block.super }}
-<script type="text/javascript">var static_url = "{% static "" %}";</script>
+<script type="text/javascript">var static_url = "{% get_static_prefix %}";</script>
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} change-list-pages{% endblock %}


### PR DESCRIPTION
Calls to the `static` template tag with an empty parameter cause exceptions when using boto3 storages:

```
ParamValidationError: Parameter validation failed:
Invalid length for parameter Key, value: 0, valid range: 1-inf
```