### PR TITLE
Update docs to reflect Django 3 support

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -55,8 +55,8 @@ Features
 Dependencies & Compatibility
 ============================
 
-  * Django 2.0
-  * Python 3.5, 3.6
+  * Django 2.0 or 3.0
+  * Python 3.6, 3.7, 3.8
   * `django-mptt <https://github.com/django-mptt/django-mptt>`_ is needed
   * `django-taggit if needed <https://github.com/alex/django-taggit>`_ (if PAGE_TAGGING = True)
   * `django-haystack if needed <http://haystacksearch.org/>`_


### PR DESCRIPTION
Noticed these small discrepancies in the docs as I was checking out the CMS for possible use in our stack (which happens to be Django 3.0 and Python 3.7)!

I updated the Django and Python versions based on recent commit history and most recent Travis CI builds. Let me know if they're not accurate, though.

